### PR TITLE
Major possible breaking fixes.

### DIFF
--- a/download_threat_information/download_threat_data.py
+++ b/download_threat_information/download_threat_data.py
@@ -24,7 +24,7 @@ CWE_XML_URL = "http://cwe.mitre.org/data/xml/cwec_latest.xml.zip"
 CVE_BASE_URL = "https://nvd.nist.gov/feeds/json/cve/1.1"
 LAST_YEAR = datetime.datetime.now().year + 1
 FIRST_YEAR = 2002
-RECENT_OFFSET = 5
+RECENT_OFFSET = 1
 CVE_ALL_YEARS = list(map(str, range(FIRST_YEAR, LAST_YEAR)))
 CVE_RECENT_YEARS = list(map(str, range(LAST_YEAR - RECENT_OFFSET, LAST_YEAR)))
 

--- a/download_threat_information/parsing_scripts/parse_attack_tactic_technique.py
+++ b/download_threat_information/parsing_scripts/parse_attack_tactic_technique.py
@@ -35,7 +35,7 @@ def link_tactic_techniques(file_name_: str, save_path: str):
         object_list = data["objects"]
         for entry in object_list:
             if entry.get("x_mitre_deprecated", False) or entry.get("revoked", False):
-                logging.info(f"Revoked or deprecated entry {entry.get('name')} {entry.get('id')}")
+                logging.debug(f"Revoked or deprecated entry {entry.get('name')} {entry.get('id')}")
                 continue
 
             tactics_set = set()
@@ -148,42 +148,55 @@ def parse_enterprise_attack(file_name: str, save_path: str):
         "intrusion-set",
         "tool",
         "malware",
+        "x-mitre-data-source",
+        "x-mitre-data-component"
     }
-    ATTACK_RELATIONSHIP_DATA = {"mitigates", "uses"}
+    ATTACK_RELATIONSHIP_DATA = {"mitigates", "uses", "detects"}
     REF_BRON_MAP = {
         "malware": "software",
         "tool": "software",
         "intrusion-set": "group",
         "attack-pattern": "technique",
+        "x-mitre-data-source": "detection",
+        "x-mitre-data-component": "detection"
     }
     values = collections.defaultdict(list)
     with open(file_name, "r") as fd:
         data = json.load(fd)
 
     attack_id_to_technique_id_map = {}
+    detection_source_to_component_map = {}
     for entry in data["objects"]:
         id_ = entry.get("id", "")
         name_ = entry.get("name", "")
         type_ = entry.get("type", "")
         if type_ in ATTACK_DATA:
             if entry.get("x_mitre_deprecated", False) or entry.get("revoked", False):
-                logging.info(f"Revoked or deprecated entry {entry.get('name')} {entry.get('id')}")
+                logging.debug(f"Revoked or deprecated entry {entry.get('name')} {entry.get('id')}")
                 continue
 
-            if type_ == "attack-pattern" and entry.get("x_mitre_detection", ""):
-                technique_id = _get_attack_id(entry)
-                category = "x_mitre_detection"
-                # TODO look at the data component and data source types
-                # TODO this makes no sense, there is no detection information here. Look at "indicators" instead
+            if type_ == "x-mitre-data-source":
+                detection_id = _get_attack_id(entry)
                 values["technique_detection"].append(
                     {
                         "name": name_,
-                        "original_id": technique_id,
-                        "detection": entry[category],
+                        "original_id": detection_id,
                         "id": id_,
+                        "description": entry["description"]
                     }
                 )
-                attack_id_to_technique_id_map[id_] = technique_id
+                attack_id_to_technique_id_map[id_] = detection_id
+            elif type_ == "x-mitre-data-component":
+                detection_id = id_
+                values["technique_detection_component"].append(
+                    {
+                        "name": name_,
+                        "original_id": detection_id,
+                        "id": id_,
+                        "description": entry["description"]
+                    }
+                )
+                detection_source_to_component_map[id_] = entry.get("x_mitre_data_source_ref")
             elif type_ == "intrusion-set":
                 group_id = _get_attack_id(entry)
                 assert group_id.startswith("G")
@@ -198,6 +211,20 @@ def parse_enterprise_attack(file_name: str, save_path: str):
                     }
                 )
                 attack_id_to_technique_id_map[id_] = group_id
+
+            elif type_ == "attack-pattern":
+                technique_id = _get_attack_id(entry)
+                assert technique_id.startswith("T")
+                # TODO will we get duplicates?
+                values["technique"].append(
+                    {
+                        "name": name_,
+                        "original_id": technique_id,
+                        "description": entry["description"],
+                        "id": id_,
+                    }
+                )
+                attack_id_to_technique_id_map[id_] = technique_id
 
             elif type_ in ("tool", "malware"):
                 software_id = _get_attack_id(entry)
@@ -232,7 +259,7 @@ def parse_enterprise_attack(file_name: str, save_path: str):
             if entry["relationship_type"] not in ATTACK_RELATIONSHIP_DATA:
                 continue
             if entry.get("x_mitre_deprecated", False) or entry.get("revoked", False):
-                logging.info(
+                logging.debug(
                     f"Relationships Revoked or deprecated entry {entry.get('name')} {entry.get('id')}"
                 )
                 continue
@@ -257,9 +284,31 @@ def parse_enterprise_attack(file_name: str, save_path: str):
                         }
                     )
 
+            elif entry["relationship_type"] == "detects":
+                if (
+                    source in detection_source_to_component_map.keys()
+                    and target in attack_id_to_technique_id_map.keys()
+                    and target != source
+                    and target_id != source_id
+                ):
+                    data_source_uuid = detection_source_to_component_map[source]
+                    data_source_id = attack_id_to_technique_id_map[data_source_uuid]
+                    values["technique_technique_detection_component_mapping"].append(
+                        {
+                            # TODO handle detection component ids
+                            #"technique_detection_component_id": source_id,
+                            "technique_data_source_id": data_source_id,
+                            "technique_id": target_id,
+                        }
+                    )
+
             elif entry["relationship_type"] == "uses":
                 source_prefix = source.split("--")[0]
                 target_prefix = target.split("--")[0]
+                if source_prefix == 'campaign' or target_prefix == 'campaign':
+                    logging.debug(f"Skipping campaign {source_prefix} {target_prefix}")
+                    continue
+                
                 try:
                     src_bron_type = REF_BRON_MAP[source_prefix]
                     tgt_bron_type = REF_BRON_MAP[target_prefix]
@@ -281,10 +330,10 @@ def parse_enterprise_attack(file_name: str, save_path: str):
                         }
                     )
 
+    assert 'software_technique_mapping' in values.keys()
     for key, value in values.items():
         file_path = os.path.join(save_path, f"{key}.jsonl")
         with open(file_path, "w") as fd:
-            print(f"Save {fd.name} {len(value)}")
             for line in value:
                 json.dump(line, fd)
                 fd.write("\n")
@@ -341,165 +390,6 @@ def link_capec_technique(save_path: str):
         fd.write(json.dumps(capec_technique_dict, indent=4, sort_keys=True))
 
     logging.info(f"End linking CAPEC to technique to {out_file}")
-
-    
-def parse_attack(file_name: str, save_path: str, domain: str = "mitre-attack", platform: str = ""):
-    logging.info(f"Begin parse ATT&CK data from {file_name}")
-    # TODO for handling of bronsprak
-    # TODO this can be parsed with stix2 library
-    ATTACK_DATA = {"attack-pattern", "course-of-action", "x-mitre-tactic"}
-    values = collections.defaultdict(list)
-    with open(file_name, "r") as fd:
-        data = json.load(fd)
-
-    attack_id_to_technique_id_map = {}
-    for entry in data["objects"]:
-        id_ = entry.get("id", "")
-        name_ = entry.get("name", "")
-        type_ = entry.get("type", "")
-        if type_ in ATTACK_DATA:
-            if entry.get("x_mitre_deprecated", False) or entry.get("revoked", False):
-                logging.info(
-                    f"Mitigations Revoked or deprecated entry {entry.get('name')} {entry.get('id')}"
-                )
-                continue
-
-            if type_ == "attack-pattern" and entry.get("x_mitre_detection", "") != "":
-                domain_str = domain
-                # TODO hacky, but also data inconsistent
-                if domain == "mitre-mobile-attack":
-                    domain_str = "mitre-attack"
-
-                technique_id = _get_attack_id(entry, domain_str)
-                if technique_id == "":
-                    technique_id = _get_attack_id(entry, domain)
-
-                if technique_id == "":
-                    logging.warning(f"No id for {name_}")
-                    continue
-
-                category = "x_mitre_detection"
-                # TODO this makes no sense, there is no detection information here. Look at "indicators" instead
-                values["technique_detection"].append(
-                    {
-                        "name": name_,
-                        "original_id": technique_id,
-                        "detection": entry[category],
-                        "id": id_,
-                    }
-                )
-                values["technique_detection_technique_mapping"].append(
-                    {
-                        "technique_detection_id": technique_id,
-                        "technique_id": technique_id,
-                    }
-                )
-                attack_id_to_technique_id_map[id_] = technique_id
-
-            if type_ == "attack-pattern":
-                domain_str = domain
-                # TODO hacky, but also data inconsistent
-                if domain == "mitre-mobile-attack":
-                    domain_str = "mitre-attack"
-
-                technique_id = _get_attack_id(entry, domain_str)
-                if technique_id == "":
-                    technique_id = _get_attack_id(entry, domain)
-
-                if technique_id == "":
-                    logging.warning(f"No id for {name_}")
-                    continue
-
-                data_value = {
-                    "name": name_,
-                    "original_id": technique_id,
-                    "description": entry["description"],
-                    "id": id_,
-                }
-                values["technique"].append(data_value)
-
-                attack_id_to_technique_id_map[id_] = technique_id
-            elif type_ == "x-mitre-tactic":
-                domain_str = domain
-                # TODO hacky, but also data inconsistent
-                if domain == "mitre-mobile-attack":
-                    domain_str = "mitre-attack"
-
-                tactic_id = _get_attack_id(entry, domain_str)
-                assert tactic_id.startswith("TA"), f"ID {tactic_id}"
-                category = "tactic"
-                values["tactic"].append(
-                    {
-                        "name": name_,
-                        "original_id": tactic_id,
-                        "description": entry["description"],
-                        "id": id_,
-                        "shortname": entry["x_mitre_shortname"],
-                    }
-                )
-                attack_id_to_technique_id_map[id_] = tactic_id
-            elif type_ == "course-of-action":
-                domain_str = domain
-                # TODO hacky, but also data inconsistent
-                if domain == "mitre-mobile-attack":
-                    domain_str = "mitre-attack"
-
-                technique_mitigation_id = _get_attack_mitigation_id(entry, domain_str)
-                if not technique_mitigation_id:
-                    continue
-                values["technique_mitigation"].append(
-                    {
-                        "name": name_,
-                        "original_id": technique_mitigation_id,
-                        "description": entry["description"],
-                        "id": id_,
-                    }
-                )
-                attack_id_to_technique_id_map[id_] = technique_mitigation_id
-
-    logging.info(f"Relationships to check {len(attack_id_to_technique_id_map)}")
-    for entry in data["objects"]:
-        if entry.get("x_mitre_deprecated", False) or entry.get("revoked", False):
-            logging.info(
-                f"Mitigations Relationships Revoked or deprecated entry {entry.get('name')} {entry.get('id')}"
-            )
-            continue
-
-        if entry["type"] == "relationship":
-            if entry["relationship_type"] == "mitigates":
-
-                source = entry["source_ref"]
-                target = entry["target_ref"]
-                source_id = attack_id_to_technique_id_map.get(source, "")
-                target_id = attack_id_to_technique_id_map.get(target, "")
-                if (
-                    source in attack_id_to_technique_id_map.keys()
-                    and target in attack_id_to_technique_id_map.keys()
-                    and source_id.startswith("M")
-                    and target != source
-                    and target_id != source_id
-                    and target_id != ""
-                ):
-                    values["technique_mitigation_technique_mapping"].append(
-                        {
-                            "technique_mitigation_id": source_id,
-                            "technique_id": target_id,
-                        }
-                    )
-                else:
-                    logging.info(f"No edge {source} - {target} ({source_id} - {target_id})")
-
-    logging.info(f"Tactic to check {len(values['tactic'])}")
-    for key, value in values.items():
-        file_path = os.path.join(save_path, f"{key}.jsonl")
-        with open(file_path, "w") as fd:
-            print(f"Save {fd.name} {len(value)}")
-            for line in value:
-                json.dump(line, fd)
-                fd.write("\n")
-
-        assert os.path.exists(file_path)
-        logging.info(f"Parsed ATT&CK data {key} from {file_name} and saved to {file_path}")
 
 
 if __name__ == "__main__":

--- a/download_threat_information/parsing_scripts/parse_capec_cwe.py
+++ b/download_threat_information/parsing_scripts/parse_capec_cwe.py
@@ -29,7 +29,7 @@ def parse_capec_xml_to_csv(capec_xml_file: str, save_path: str) -> None:
     els = root.findall("./capec-3:Attack_Patterns/capec-3:Attack_Pattern", ns)
     for el in els:
         if el.attrib["Status"] == "Deprecated":
-            logging.info(f"Deprecated CAPEC entry {el.attrib['ID']} {el.attrib['Name']}")
+            logging.debug(f"Deprecated CAPEC entry {el.attrib['ID']} {el.attrib['Name']}")
             continue
 
         # TODO read from schema
@@ -169,7 +169,7 @@ def parse_cwe_xml_to_csv(cwe_file: str, save_path: str, download_path: str) -> N
     els = root.findall(f"./{CWE_VERSION_TAG}:Weaknesses/{CWE_VERSION_TAG}:Weakness", ns)
     for el in els:
         if el.attrib["Status"] == "Deprecated":
-            logging.info(f"Deprecated CWE entry {el.attrib['ID']} {el.attrib['Name']}")
+            logging.debug(f"Deprecated CWE entry {el.attrib['ID']} {el.attrib['Name']}")
             continue
 
         values = {
@@ -311,8 +311,8 @@ def parse_capec_cwe_files(save_path):
         capec_name = capec_entry["Name"]
         data["capec_names"][capec_id] = capec_name
         data["capec_descriptions"][capec_id] = {
-            "short_description": capec_entry["Description"],
-            "description": capec_entry["Extended_Description"],
+            "description": capec_entry["Description"],
+            "extended_description": capec_entry["Extended_Description"],
             "likelihood_of_attack": capec_entry["Likelihood of Attack"],
             "typical_severity": capec_entry["Typical Severity"],
             "skills_required": capec_entry["Skills Required"],

--- a/graph_db/bron_arango.py
+++ b/graph_db/bron_arango.py
@@ -298,15 +298,16 @@ def import_into_arango(
     client = get_bron_db(username, password, ip)
     db = client.db(DB, username, password, auth_method="basic")
     if name in db.collections():
+        collection = db.collection(name)
         logging.info(f"Existing {DB} on {ip} collection {name} count {collection.count()}")
             
     process = subprocess.run(cmd, capture_output=True, check=True, text=True)
     log_arangoimport_output(str(process.stdout), str(process.stderr), file_, name)
     
     collection = db.collection(name)
-    client.close()
     assert collection.count() > 0
     logging.info(f"Imported {name} from {file_} to {DB} on {ip} collection {name} count {collection.count()}")
+    client.close()
 
 
 def arango_import(username: str, password: str, ip: str) -> None:

--- a/graph_db/same_datasource_links.py
+++ b/graph_db/same_datasource_links.py
@@ -8,9 +8,8 @@ import logging
 import arango
 import dotenv
 
-from graph_db.bron_arango import DB, validate_entry
+from graph_db.bron_arango import DB, create_edge_document, validate_entry, import_into_arango
 from utils.mitigation_utils import (
-    import_into_arango,
     query_bron,
     update_graph_in_graph_db,
 )
@@ -44,12 +43,9 @@ def make_edges(
             except TypeError as e:
                 logging.error(f"{value} not found in {bron_collection}. {e}")
                 continue
-
-            entry = {"_from": _from, "_to": _to}
-            if validation:
-                validate_entry(entry, schema)
-
-            edges.append(entry)
+            
+            document = create_edge_document(_from, _to, schema, validation)            
+            edges.append(document)
 
     with open(out_file, "w") as fd:
         for edge in edges:

--- a/graph_db/schemas/capec_detection_schema.json
+++ b/graph_db/schemas/capec_detection_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'capec_detection_00581'",
+          "description":"The unique identifier for BRON. ",
           "type":"string",
-          "pattern": "capec_detection_\\d{5}"
+          "pattern": "CA-\\d{1,3}"
        },
        "original_id":{
         "description":"ID from MITRE CAPEC. E.g. '1'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the attack pattern. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
         "description":"Indicators field in CAPEC entry",

--- a/graph_db/schemas/capec_mitigation_schema.json
+++ b/graph_db/schemas/capec_mitigation_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'capec_mitigation_00581'",
+          "description":"The unique identifier for BRON.",
           "type":"string",
-          "pattern": "capec_mitigation_\\d{5}"
+          "pattern": "CA-\\d{1,3}"
        },
        "original_id":{
         "description":"ID from MITRE CAPEC. E.g. '1'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the attack pattern. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
         "description":"Mitigation field in CAPEC entry",

--- a/graph_db/schemas/capec_schema.json
+++ b/graph_db/schemas/capec_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'capec_00581'",
-          "type":"string",
-          "pattern": "capec_\\d{5}"
+        "description":"The unique identifier for BRON. ",
+        "type":"string",
+        "pattern": "CA-\\d{1,3}"
        },
        "original_id":{
         "description":"ID from MITRE CAPEC. E.g. '1'",
@@ -21,17 +21,18 @@
        },
        "name":{
         "description":"The name of the attack pattern. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
         "description":"Metadata",
         "type":"object",
         "properties": {
-            "description": {
-                "description": "The extended description",
+            "extended_description": {
+                "extended_description": "The extended description",
                 "type": "string"
             },
-            "short_description": {
+            "description": {
                 "description": "The description",
                 "type": "string"
             },
@@ -97,7 +98,7 @@
             },
             "required":[
                 "description",
-                "short_description"
+                "extended_description"
              ]         
        }
     },

--- a/graph_db/schemas/cpe_schema.json
+++ b/graph_db/schemas/cpe_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'cpe_02052'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "cpe_\\d{5}"
+          "pattern": "cpe:2\\.3:[aho\\*\\-](:(((\\?*|\\*?)([a-zA-Z0-9\\-\\._]|(\\\\[\\\\\\*\\?!\"#$$%&'\\(\\)\\+,/:;<=>@\\[\\]\\^`\\{\\|}~]))+(\\?*|\\*?))|[\\*\\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\\*\\-]))(:(((\\?*|\\*?)([a-zA-Z0-9\\-\\._]|(\\\\[\\\\\\*\\?!\"#$$%&'\\(\\)\\+,/:;<=>@\\[\\]\\^`\\{\\|}~]))+(\\?*|\\*?))|[\\*\\-])){4}"
        },
        "original_id":{
         "description":"ID in CPE form . E.g. 'cpe:2.3:o:freebsd:freebsd:2.1.6:*:*:*:*:*:*:*'. Pattern to work as described in https://csrc.nist.gov/schema/cpe/2.3/cpe-naming_2.3.xsd",

--- a/graph_db/schemas/cve_schema.json
+++ b/graph_db/schemas/cve_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'cve_00581'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "cve_\\d{5,}"
+          "pattern": "CVE-\\d{4}-\\d{4,7}"
        },
        "original_id":{
         "description":"ID from NIST CVE. E.g. ''",

--- a/graph_db/schemas/cwe_detection_schema.json
+++ b/graph_db/schemas/cwe_detection_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'cwe_detection_00017'",
+          "description":"The unique identifier for BRON. ",
           "type":"string",
-          "pattern": "cwe_detection_\\d{5}"
+          "pattern": "CWE-\\d{1,4}"
        },
        "original_id":{
         "description":"ID from MITRE CWE. E.g. '1'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the weakness. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
          "description":"Metadata. Information taken from the Detection Methods",
@@ -29,7 +30,8 @@
          "properties": {
              "Description": {
                  "description": "The description",
-                 "type": "string"
+                 "type": "string",
+                 "minLength": 1
              },
              "Method": {
                  "description": "The Method. TODO pattern?",

--- a/graph_db/schemas/cwe_mitigation_schema.json
+++ b/graph_db/schemas/cwe_mitigation_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'cwe_mitigation_00000'",
+          "description":"The unique identifier for BRON. ",
           "type":"string",
-          "pattern": "cwe_mitigation_\\d{5}"
+          "pattern": "CWE-\\d{1,4}"
        },
        "original_id":{
         "description":"ID from MITRE CWE. E.g. '1'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the weakness. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
          "description":"Metadata. Information taken from the Potential Mitigations",
@@ -29,7 +30,8 @@
          "properties": {
              "Description": {
                  "description": "The description",
-                 "type": "string"
+                 "type": "string",
+                 "minLength": 1
              },
              "Phase": {
                  "description": "The phase. TODO pattern?",

--- a/graph_db/schemas/cwe_schema.json
+++ b/graph_db/schemas/cwe_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'cwe_01127'",
+          "description":"The unique identifier for BRON.",
           "type":"string",
-          "pattern": "cwe_\\d{5}"
+          "pattern": "CWE-\\d{1,4}"
        },
        "original_id":{
         "description":"ID from MITRE CWE. E.g. '1004'",
@@ -21,19 +21,20 @@
        },
        "name":{
         "description":"The name of the weakness. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
         "description":"Metadata",
         "type":"object",
         "properties": {
-            "description": {
+            "extended_description": {
                 "description": "The extended description",
-                "type": ["string", "null"]
-            },
-            "short_description": {
-                "description": "The description",
                 "type": "string"
+            },
+            "description": {
+                "description": "The description",
+                "type": ["string", "null"]
             },
             "likelihood_of_exploit": {
                 "description": "The likelihood of exploit. TODO get the patterns",
@@ -73,8 +74,7 @@
             }            
             },
             "required":[
-                "description",
-                "short_description"
+                "description"
              ]
        }
     },

--- a/graph_db/schemas/d3fend_mitigation_schema.json
+++ b/graph_db/schemas/d3fend_mitigation_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'd3fend_mitigation_00000'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "d3fend_mitigation_\\d{5}"
+          "pattern": "D3[A-Z]?-[A-Z]+"
        },
        "original_id":{
         "description":"ID from MITRE D3FEND. E.g. 'ActiveCertificateAnalysis'. TODO pattern",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the mitigation. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
          "description":"Metadata.",
@@ -29,7 +30,8 @@
          "properties": {
             "description": {
                 "description": "The full comment",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
             },
             "required":[

--- a/graph_db/schemas/edge_collections/CapecCapec_detection_schema.json
+++ b/graph_db/schemas/edge_collections/CapecCapec_detection_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The attack pattern identifier in BRON.",
          "type":"string",
-         "pattern": "capec/capec_\\d{5}"
+         "pattern": "capec/CA-\\d{1,3}"
       },
       "_to":{
          "description":"The attack pattern detection identifier in BRON.",
          "type":"string",
-         "pattern": "capec_detection/capec_detection_\\d{5}"
+         "pattern": "capec_detection/CA-\\d{1,3}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/CapecCapec_mitigation_schema.json
+++ b/graph_db/schemas/edge_collections/CapecCapec_mitigation_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The attack pattern identifier in BRON.",
          "type":"string",
-         "pattern": "capec/capec_\\d{5}"
+         "pattern": "capec/CA-\\d{1,3}"
       },
       "_to":{
          "description":"The attack pattern mitigation identifier in BRON.",
          "type":"string",
-         "pattern": "capec_mitigation/capec_mitigation_\\d{5}"
+         "pattern": "capec_mitigation/CA-\\d{1,3}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/CapecCapec_schema.json
+++ b/graph_db/schemas/edge_collections/CapecCapec_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The attack pattern identifier in BRON.",
          "type":"string",
-         "pattern": "capec/capec_\\d{5}"
+         "pattern": "capec/CA-\\d{1,3}"
       },
       "_to":{
          "description":"The sub attack pattern identifier in BRON.",
          "type":"string",
-         "pattern": "capec/capec_\\d{5}"
+         "pattern": "capec/CA-\\d{1,3}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/CapecCwe_schema.json
+++ b/graph_db/schemas/edge_collections/CapecCwe_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The attack pattern identifier in BRON.",
          "type":"string",
-         "pattern": "capec/capec_\\d{5}"
+         "pattern": "capec/CA-\\d{1,3}"
       },
       "_to":{
          "description":"The weakness identifier in BRON.",
          "type":"string",
-         "pattern": "cwe/cwe_\\d{5}"
+         "pattern": "cwe/CWE-\\d{1,4}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/CveCpe_schema.json
+++ b/graph_db/schemas/edge_collections/CveCpe_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The vulnerability identifier in BRON.",
          "type":"string",
-         "pattern": "cve/cve_\\d{5}"
+         "pattern": "cve/CVE-\\d{4}-\\d{4,7}"
       },
       "_to":{
          "description":"The product configuration identifier in BRON.",
          "type":"string",
-         "pattern": "cpe/cpe_\\d{5}"
+         "pattern": "cpe/cpe:2\\.3:[aho\\*\\-](:(((\\?*|\\*?)([a-zA-Z0-9\\-\\._]|(\\\\[\\\\\\*\\?!\"#$$%&'\\(\\)\\+,/:;<=>@\\[\\]\\^`\\{\\|}~]))+(\\?*|\\*?))|[\\*\\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\\*\\-]))(:(((\\?*|\\*?)([a-zA-Z0-9\\-\\._]|(\\\\[\\\\\\*\\?!\"#$$%&'\\(\\)\\+,/:;<=>@\\[\\]\\^`\\{\\|}~]))+(\\?*|\\*?))|[\\*\\-])){4}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/CweCve_schema.json
+++ b/graph_db/schemas/edge_collections/CweCve_schema.json
@@ -7,12 +7,12 @@
       "_to":{
          "description":"The vulnerability identifier in BRON.",
          "type":"string",
-         "pattern": "cve/cve_\\d{5}"
+         "pattern": "cve/CVE-\\d{4}-\\d{4,7}"
       },
       "_from":{
          "description":"The weakness identifier in BRON.",
          "type":"string",
-         "pattern": "cwe/cwe_\\d{5}"
+         "pattern": "cwe/CWE-\\d{1,4}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/CweCwe_detection_schema.json
+++ b/graph_db/schemas/edge_collections/CweCwe_detection_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The weakness identifier in BRON.",
          "type":"string",
-         "pattern": "cwe/cwe_\\d{5}"
+         "pattern": "cwe/CWE-\\d{1,4}"
       },
       "_to":{
          "description":"The weakness detection identifier in BRON.",
          "type":"string",
-         "pattern": "cwe_detection/cwe_detection_\\d{5}"
+         "pattern": "cwe_detection/CWE-\\d{1,4}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/CweCwe_mitigation_schema.json
+++ b/graph_db/schemas/edge_collections/CweCwe_mitigation_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The weakness identifier in BRON.",
          "type":"string",
-         "pattern": "cwe/cwe_\\d{5}"
+         "pattern": "cwe/CWE-\\d{1,4}"
       },
       "_to":{
          "description":"The weakness mitigation identifier in BRON.",
          "type":"string",
-         "pattern": "cwe_mitigation/cwe_mitigation_\\d{5}"
+         "pattern": "cwe_mitigation/CWE-\\d{1,4}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/CweCwe_schema.json
+++ b/graph_db/schemas/edge_collections/CweCwe_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The weakness identifier in BRON.",
          "type":"string",
-         "pattern": "cwe/cwe_\\d{5}"
+         "pattern": "cwe/CWE-\\d{1,4}"
       },
       "_to":{
          "description":"The weakness identifier in BRON.",
          "type":"string",
-         "pattern": "cwe/cwe_\\d{5}"
+         "pattern": "cwe/CWE-\\d{1,4}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/D3fend_mitigationTechnique_schema.json
+++ b/graph_db/schemas/edge_collections/D3fend_mitigationTechnique_schema.json
@@ -7,12 +7,12 @@
       "_to":{
          "description":"The defensive mitigation identifier in BRON.",
          "type":"string",
-         "pattern": "d3fend_mitigation/d3fend_mitigation_\\d{5}"
+         "pattern": "d3fend_mitigation/D3[A-Z]?-[A-Z]+"
       },
       "_from":{
          "description":"The technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/Engage_approachEngage_activity_schema.json
+++ b/graph_db/schemas/edge_collections/Engage_approachEngage_activity_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The approach identifier in BRON.",
          "type":"string",
-         "pattern": "engage_approach/engage_approach_\\d{5}"
+         "pattern": "engage_approach/[ES]AP\\d{4}"
       },
       "_to":{
          "description":"The activity identifier in BRON.",
          "type":"string",
-         "pattern": "engage_activity/engage_activity_\\d{5}"
+         "pattern": "engage_activity/[ES]AC\\d{4}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/Engage_goalEngage_approach_schema.json
+++ b/graph_db/schemas/edge_collections/Engage_goalEngage_approach_schema.json
@@ -7,12 +7,12 @@
       "_to":{
          "description":"The approach identifier in BRON.",
          "type":"string",
-         "pattern": "engage_approach/engage_approach_\\d{5}"
+         "pattern": "engage_approach/[ES]AP\\d{4}"
       },
       "_from":{
          "description":"The goal identifier in BRON.",
          "type":"string",
-         "pattern": "engage_goal/engage_goal_\\d{5}"
+         "pattern": "engage_goal/[ES]GO\\d{4}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/GroupSoftware_schema.json
+++ b/graph_db/schemas/edge_collections/GroupSoftware_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The group identifier in BRON.",
          "type":"string",
-         "pattern": "group/group_\\d{5}"
+         "pattern": "group/G\\d{4}"
       },
       "_to":{
          "description":"The software identifier in BRON.",
          "type":"string",
-         "pattern": "software/software_\\d{5}"
+         "pattern": "software/S\\d{4}"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/GroupTechnique_schema.json
+++ b/graph_db/schemas/edge_collections/GroupTechnique_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The group identifier in BRON.",
          "type":"string",
-         "pattern": "group/group_\\d{5}"
+         "pattern": "group/G\\d{4}"
       },
       "_to":{
          "description":"The technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/SoftwareTechnique_schema.json
+++ b/graph_db/schemas/edge_collections/SoftwareTechnique_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The software identifier in BRON.",
          "type":"string",
-         "pattern": "software/software_\\d{5}"
+         "pattern": "software/S\\d{4}"
       },
       "_to":{
          "description":"The technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/TacticTechnique_schema.json
+++ b/graph_db/schemas/edge_collections/TacticTechnique_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The tactic identifier in BRON.",
          "type":"string",
-         "pattern": "tactic/tactic_\\d{5}"
+         "pattern": "tactic/TA\\d{4}"
       },
       "_to":{
          "description":"The technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/TechniqueCapec_schema.json
+++ b/graph_db/schemas/edge_collections/TechniqueCapec_schema.json
@@ -7,12 +7,12 @@
       "_to":{
          "description":"The attack pattern identifier in BRON.",
          "type":"string",
-         "pattern": "capec/capec_\\d{5}"
+         "pattern": "capec/CA-\\d{1,3}"
       },
       "_from":{
          "description":"The technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/TechniqueEngage_activity_schema.json
+++ b/graph_db/schemas/edge_collections/TechniqueEngage_activity_schema.json
@@ -7,12 +7,12 @@
       "_to":{
          "description":"The activity identifier in BRON.",
          "type":"string",
-         "pattern": "engage_activity/engage_activity_\\d{5}"
+         "pattern": "engage_activity/[ES]AC\\d{4}"
       },
       "_from":{
          "description":"The technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/TechniqueTechnique_detection_schema.json
+++ b/graph_db/schemas/edge_collections/TechniqueTechnique_detection_schema.json
@@ -7,12 +7,12 @@
       "_to":{
          "description":"The detection identifier in BRON.",
          "type":"string",
-         "pattern": "technique_detection/technique_detection_\\d{5}"
+         "pattern": "technique_detection/DS\\d{4}"
       },
       "_from":{
          "description":"The technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/TechniqueTechnique_mitigation_schema.json
+++ b/graph_db/schemas/edge_collections/TechniqueTechnique_mitigation_schema.json
@@ -7,12 +7,12 @@
       "_to":{
          "description":"The mitigation identifier in BRON.",
          "type":"string",
-         "pattern": "technique_mitigation/technique_mitigation_\\d{5}"
+         "pattern": "technique_mitigation/M\\d{4}"
       },
       "_from":{
          "description":"The technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       }
  },
     "required":[

--- a/graph_db/schemas/edge_collections/TechniqueTechnique_schema.json
+++ b/graph_db/schemas/edge_collections/TechniqueTechnique_schema.json
@@ -7,12 +7,12 @@
       "_from":{
          "description":"The technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       },
       "_to":{
          "description":"The sub technique identifier in BRON.",
          "type":"string",
-         "pattern": "technique/technique_\\d{5}"
+         "pattern": "technique/(T\\d{4}(\\.\\d{3})?)"
       }
  },
     "required":[

--- a/graph_db/schemas/engage_activity_schema.json
+++ b/graph_db/schemas/engage_activity_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'engage_activity_00000'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "engage_activity_\\d{5}"
+          "pattern": "[ES]AC\\d{4}"
        },
        "original_id":{
         "description":"ID from MITRE ENGAGE. E.g. 'EAC0001'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the activity. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        }
     },
     "required":[

--- a/graph_db/schemas/engage_approach_schema.json
+++ b/graph_db/schemas/engage_approach_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'engage_approach_00000'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "engage_approach_\\d{5}"
+          "pattern": "[ES]AP\\d{4}"
        },
        "original_id":{
         "description":"ID from MITRE ENGAGE. E.g. 'EAP0001'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the approach. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        }
     },
     "required":[

--- a/graph_db/schemas/engage_goal_schema.json
+++ b/graph_db/schemas/engage_goal_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'engage_goal_00000'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "engage_goal_\\d{5}"
+          "pattern": "[ES]GO\\d{4}"
        },
        "original_id":{
         "description":"ID from MITRE ENGAGE. E.g. 'SGO0001'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the goal. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        }
     },
     "required":[

--- a/graph_db/schemas/group_schema.json
+++ b/graph_db/schemas/group_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'group_00000'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "group_\\d{5}"
+          "pattern": "G\\d{4}"
        },
        "original_id":{
         "description":"ID from MITRE ATT&CK. E.g. 'G1013'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the group. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
         "description":"Metadata",
@@ -29,7 +30,8 @@
         "properties": {
             "description": {
                 "description": "The full description",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             },
             "aliases": {
                 "description": "The aliases. TODO write pattern and that the type is list",

--- a/graph_db/schemas/software_schema.json
+++ b/graph_db/schemas/software_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'software_00000'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "software_\\d{5}"
+          "pattern": "S\\d{4}"
        },
        "original_id":{
         "description":"ID from MITRE ATT&CK. E.g. 'S1013'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The name of the software. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
         "description":"Metadata",
@@ -29,7 +30,8 @@
         "properties": {
             "description": {
                 "description": "The full description",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             },
             "type": {
                 "description": "The type. TODO write pattern",

--- a/graph_db/schemas/tactic_schema.json
+++ b/graph_db/schemas/tactic_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'tactic_00001'",
+          "description":"The unique identifier for BRON.Same as data source",
           "type":"string",
-          "pattern": "tactic_\\d{5}"
+          "pattern": "TA\\d{4}"
        },
        "original_id":{
         "description":"ID from MITRE ATT&CK. E.g. 'TA0001'",
@@ -21,7 +21,8 @@
        },
        "name":{
         "description":"The shortname of the tactic. TODO write pattern",
-        "type":"string"
+        "type":"string",
+        "minLength": 1
        },
        "metadata":{
         "description":"Metadata",
@@ -29,11 +30,13 @@
         "properties": {
             "description": {
                 "description": "The full description",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             },
             "short_description": {
                 "description": "The first line of the description. TODO write pattern",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
             },
             "required":[

--- a/graph_db/schemas/technique_detection_schema.json
+++ b/graph_db/schemas/technique_detection_schema.json
@@ -1,18 +1,18 @@
 {
     "$schema":"http://json-schema.org/draft-07/schema#",
     "title":"technique_detection",
-    "description":"A detection of an ATT&CK technique. TODO currently this makes no sense",
+    "description":"A detection of an ATT&CK technique.",
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'technique_detection_00000'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "technique_detection_\\d{5}"
+          "pattern": "DS\\d{4}"
        },
        "original_id":{
-        "description":"ID from MITRE ATT&CK. E.g. 'T1001'",
+        "description":"ID from MITRE ATT&CK. E.g. 'DS1001'",
         "type":"string",
-        "pattern": "(T\\d{4}(\\.\\d{3})?)"
+        "pattern": "DS\\d{4}"
        },
        "datatype":{
         "description":"Name of datasource",
@@ -21,13 +21,29 @@
        },
        "name":{
         "description":"The name of the detection. TODO write pattern",
-        "type":"string"
-       }
+        "type":"string",
+        "minLength": 1
+       },
+       "metadata":{
+         "description":"Metadata",
+         "type":"object",
+         "properties": {
+             "description": {
+                 "description": "The full description",
+                 "type": "string",
+                 "minLength": 1
+             }
+            },
+             "required":[
+                 "description"
+              ]         
+        }
     },
     "required":[
         "_key",
         "name",
         "datatype",
-        "original_id"
+        "original_id",
+        "metadata"
      ]
   }

--- a/graph_db/schemas/technique_mitigation_schema.json
+++ b/graph_db/schemas/technique_mitigation_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'technique_mitigation_00000'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "technique_mitigation_\\d{5}"
+          "pattern": "M\\d{4}"
        },
        "original_id":{
         "description":"ID from MITRE ATT&CK. E.g. 'M1013'",
@@ -22,12 +22,27 @@
        "name":{
         "description":"The name of the mitigation. TODO write pattern",
         "type":"string"
-       }
+       },
+       "metadata":{
+         "description":"Metadata",
+         "type":"object",
+         "properties": {
+             "description": {
+                 "description": "The full description",
+                 "type": "string",
+                 "minLength": 1
+             }
+            },
+             "required":[
+                 "description"
+              ]         
+        }
     },
     "required":[
         "_key",
         "name",
         "datatype",
-        "original_id"
+        "original_id",
+        "metadata"
      ]
   }

--- a/graph_db/schemas/technique_schema.json
+++ b/graph_db/schemas/technique_schema.json
@@ -5,9 +5,9 @@
     "type":"object",
     "properties":{
        "_key":{
-          "description":"The unique identifier for BRON. E.g. 'technique_00001'",
+          "description":"The unique identifier for BRON. Same as data source",
           "type":"string",
-          "pattern": "technique_\\d{5}"
+          "pattern": "(T\\d{4}(\\.\\d{3})?)"
        },
        "original_id":{
         "description":"ID from MITRE ATT&CK. E.g. 'T1001'",
@@ -29,7 +29,8 @@
         "properties": {
             "description": {
                 "description": "The full description",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             },
             "short_description": {
                 "description": "The first paragraph of the description. TODO write pattern",

--- a/mitigations/query_d3fend.py
+++ b/mitigations/query_d3fend.py
@@ -1,6 +1,8 @@
 import json
 import argparse
 import collections
+import logging
+import os
 import sys
 from typing import Any, List, Dict, Tuple, Set
 
@@ -61,7 +63,9 @@ def find_artifacts(g: Any) -> List[str]:
         """
     qres = g.query(query)
     artifacts = []
+    logging.info(f"ARTIFACT QUERY: {query}")
     for row in qres:
+        logging.info(f"ARTIFACTS {row}")
         value = str(row[0]).split("#")[-1]
         artifacts.append(value)
 
@@ -95,12 +99,15 @@ def find_mitigation_artifacts(mitigation, artifacts, g) -> List[str]:
     )
     qres = g.query(query)
     related_artifacts = set()
-    for row in qres:
+    logging.info(f"SPARQL Artifact query: {query}")
+    for row in qres:        
         for value in row:
             str_value = str(value)
             if str_value.startswith(D3F_URI):
                 artifact = str_value.split("#")[-1]
+                logging.info(f"Row: {row} {str_value} {artifact}")
                 if artifact in artifacts:
+                    logging.info(f"Results: {artifact} {artifacts}")
                     related_artifacts.add(artifact)
 
     return related_artifacts
@@ -121,22 +128,16 @@ def find_mitigation_label(mitigation, g) -> List[str]:
     return label
 
 
-def find_mitigation_comment(mitigation, g) -> List[str]:
-    query = """SELECT *
-        WHERE {{
-            <{}#{}> rdfs:comment ?b .
-        }}
-        """.format(
-        D3F_URI, mitigation
-    )
-    qres = g.query(query)
-    label = ""
-    for row in qres:
-        label = str(row[0])
+def find_mitigation_comment(data: List[Dict[str, str]], id_: str) -> str:
+    # TODO SPARQL
+    for entry in data:
+        if entry.get("d3f:d3fend-id") == id_:
+            description = f"{entry.get('d3f:definition', '')}\n{entry.get('d3f:kb-article')}"
+            return description
+        
+    return ""
 
-    return label
-
-
+        
 def find_techniques_from_mitigations() -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
     g = rdflib.Graph()
     _ = g.parse(D3FEND_ONTOLOGY_TTL, format="turtle")
@@ -147,14 +148,17 @@ def find_techniques_from_mitigations() -> Tuple[Dict[str, Set[str]], Dict[str, S
     technique_mitigation_map = collections.defaultdict(set)
     # TODO SPARQL should be able to do this "join".
     # TODO Try traversing the graph (as in Query 3 https://www.w3.org/2009/Talks/0615-qbe/)
+    logging.info(f"Found {len(mitigations)} mitigations and {len(artifacts)}")
     for mitigtaion_id, mitigation in mitigations.items():
         mitigation_artifacts = find_mitigation_artifacts(mitigation, artifacts, g)
+        #logging.info(f"Found {len(mitigation_artifacts)} artifacts for {mitigation}")
         for artifact in mitigation_artifacts:
             techniques_ = find_techniques_from_mitigation(artifact, g)
             for technique_ in techniques_:
                 mitigation_technique_map[mitigation].add(technique_)
                 technique_mitigation_map[technique_].add(mitigtaion_id)
 
+    assert len(mitigation_technique_map) > 0
     return mitigation_technique_map, technique_mitigation_map
 
 
@@ -202,6 +206,30 @@ def find_capecs_from_mitigations_given_network(
     matches = get_network_matches(results, network_description)
     return matches
 
+
+def find_techniques_from_mitigations_map(d3fend_mapping_file_name: str, d3fend_label_id_map: Dict[str, str]) -> Dict[str, List[Tuple[str, str]]]:
+    with open(d3fend_mapping_file_name, 'r') as fd:
+        data = json.load(fd)
+
+    bindings = data["results"]["bindings"]
+    assert len(bindings) > 0
+    # TODO technique-tactic infered information as well?
+    d3fend_technique_maps = set()
+    d3fend_d3fend_maps = set()
+    # TODO d3fend tactics map
+    for binding in bindings:
+        d3fend_label = binding["def_tech_label"]["value"].replace(" ", "")
+        d3fend_id = d3fend_label_id_map[d3fend_label]
+        technique_id = binding["off_tech"]["value"].split("#")[-1]
+        d3fend_technique_maps.add((d3fend_id, technique_id))
+
+        d3fend_top_level_label = binding["top_def_tech_label"]["value"].replace(" ", "")
+        d3fend_top_level_id = d3fend_label_id_map[d3fend_top_level_label]
+        d3fend_d3fend_maps.add((d3fend_id, d3fend_top_level_id))
+                
+    return {"d3fend_technique": list(d3fend_technique_maps), 
+            "d3fend_d3fend": list(d3fend_d3fend_maps),
+            }
 
 def parse_args(args: List[str]) -> Dict[str, Any]:
     parser = argparse.ArgumentParser(description="Query D3FEND and BRON")


### PR DESCRIPTION
Fixes:
- Change BRON ID. Use `original_id` from the data source as the document id and `_key` when it contains a prefix, e.g. `TA1001`. A prefix is added for `CWE` and `CAPEC` documents.
- Fix Duplicate Edges. Edge `_key` is set in `create_edge_document`
- Improve logging. Log output from `arangoimport` to simplify duplication detection
- Fix descriptions for Technique detection and D3FEND
- Update document schemas
- Fix links for Technique detections
- Updated some logging to `debug` from `info`
- Changed `short_description` to `description` and `description` to `extended_description` for `CWE` and `CAPEC`
- Use `d3fend-full-mapping.json` for D3FEND links
- Clean code